### PR TITLE
Remove dependency on `unstable/contract`.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,4 +1,4 @@
 #lang info
 (define collection 'multi)
-(define deps '("base" "unstable-contract-lib"))
-(define build-deps '("eli-tester" "racket-doc" "scribble-lib" "unstable-doc"))
+(define deps '(("base" #:version "6.2.900.15")))
+(define build-deps '("eli-tester" "racket-doc" "scribble-lib"))

--- a/net/ldap.rkt
+++ b/net/ldap.rkt
@@ -8,8 +8,7 @@ http://en.wikipedia.org/wiki/Basic_Encoding_Rules
 https://www.opends.org/wiki/page/DefBasicEncodingRules
 
 |#
-(require unstable/contract
-         racket/contract
+(require racket/contract
          racket/tcp
          racket/match)
 

--- a/net/ldap/ldap.scrbl
+++ b/net/ldap/ldap.scrbl
@@ -1,7 +1,7 @@
 #lang scribble/doc
 @(require scribble/manual
           (for-label racket
-                     unstable/contract
+                     racket/tcp
                      net/ldap))
 
 @title{LDAP}


### PR DESCRIPTION
Most of the functionality of that library has been moved to `racket/contract`, and `unstable/contract` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2.1. To preserve compatibility, you can create a Racket 6.2.1-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-contract-lib` package, as it will not be part of the main distribution in future versions. If you decide to go with that option, please keep a dependency to `unstable-contract-lib`.
